### PR TITLE
Add support for italian language Fritz.

### DIFF
--- a/metrics-lua.json
+++ b/metrics-lua.json
@@ -1,11 +1,11 @@
 {
     "labelRenames": [
         {
-            "matchRegex": "(?i)prozessor",
+            "matchRegex": "(?i)^(?:prozessor|processore)",
             "renameLabel": "CPU"
         },
         {
-            "matchRegex": "(?i)system",
+            "matchRegex": "(?i)^(?:system|sistema)",
             "renameLabel": "System"
         },
         {
@@ -177,4 +177,3 @@
         }        
     ]
 }
-


### PR DESCRIPTION
I also added anchor to start of string, but I only guess that's right for German too.
Else, we can use:
`"matchRegex": "(?i)prozessor|processore"`