### PR TITLE
Go version in go.mod fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build Image
 FROM golang:1.23-alpine3.21 AS builder
-RUN go install github.com/sberk42/fritzbox_exporter@latest \
+RUN go install github.com/az82/fritzbox_exporter@latest \
     && mkdir /app \
     && mv /go/bin/fritzbox_exporter /app
 
@@ -13,7 +13,7 @@ COPY metrics.json metrics-lua.json /app/
 # Runtime Image
 FROM alpine:3.21 as runtime-image
 
-ARG REPO=sberk42/fritzbox_exporter
+ARG REPO=az82/fritzbox_exporter
 
 LABEL org.opencontainers.image.source https://github.com/${REPO}
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Other changes:
 
 ## Building
 
-    go install github.com/sberk42/fritzbox_exporter@latest
+    go install github.com/az82/fritzbox_exporter@latest
 
 ## Running
 
@@ -45,7 +45,7 @@ Heimnetzübersicht > Netzwerkeinstellungen" has to be enabled.
 ### Using docker
 
 The image is available as package using:
-`docker pull ghcr.io/sberk42/fritzbox_exporter/fritzbox_exporter:latest`
+`docker pull ghcr.io/az82/fritzbox_exporter/fritzbox_exporter:latest`
 or you can build the container yourself: `docker build --tag fritzbox-prometheus-exporter:latest .`
 
 Then start the container:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sberk42/fritzbox_exporter
 
-go 1.23.4
+go 1.23
 
 require (
 	github.com/namsral/flag v1.7.4-pre

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sberk42/fritzbox_exporter
+module github.com/az82/fritzbox_exporter
 
 go 1.23
 

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
-	lua "github.com/sberk42/fritzbox_exporter/fritzbox_lua"
-	upnp "github.com/sberk42/fritzbox_exporter/fritzbox_upnp"
+	lua "github.com/az82/fritzbox_exporter/fritzbox_lua"
+	upnp "github.com/az82/fritzbox_exporter/fritzbox_upnp"
 )
 
 const serviceLoadRetryTime = 1 * time.Minute


### PR DESCRIPTION
Fixes:

go: github.com/sberk42/fritzbox_exporter@latest (in github.com/sberk42/fritzbox_exporter@v0.0.0-20250415190106-8e511bf7b4a6): go.mod:3: invalid go version '1.23.4': must match format 1.23"