### PR TITLE
Refactor docker-compose.yml to support .env/stack.env variable injection for GitOps and Portainer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,17 @@ services:
     #expose:
     #  - "9042"
     restart: unless-stopped
+
+    # environment values can be passed via .env file
+    # these defaults are commented out and can be overridden in a stack.env or .env file
+    # environment:
+    #   USERNAME: your_fritzbox_username
+    #   PASSWORD: your_fritzbox_password
+    #   GATEWAY_URL: http://192.168.0.1:49000
+    #   LISTEN_ADDRESS: 0.0.0.0:9042
+
     environment:
-      USERNAME: your_fritzbox_username 
-      PASSWORD: your_fritzbox_password
-      GATEWAY_URL: http://192.168.0.1:49000
-      LISTEN_ADDRESS: 0.0.0.0:9042
+      - USERNAME
+      - PASSWORD
+      - GATEWAY_URL
+      - LISTEN_ADDRESS


### PR DESCRIPTION
## Summary

This pull request updates the `docker-compose.yml` to improve compatibility with modern deployment workflows such as:

- Docker Compose `.env` files
- Portainer's `stack.env` handling
- GitOps-based automatic deployments

## What was changed

The current `environment:` block in the compose file hardcodes example credentials like:

```yaml
environment:
  USERNAME: your_fritzbox_username
  PASSWORD: your_fritzbox_password
  GATEWAY_URL: http://192.168.0.1:49000
  LISTEN_ADDRESS: 0.0.0.0:9042
```

This PR comments out the hardcoded section and replaces it with environment variable references:

```yaml
# environment:
#   USERNAME: your_fritzbox_username
#   PASSWORD: your_fritzbox_password
#   GATEWAY_URL: http://192.168.0.1:49000
#   LISTEN_ADDRESS: 0.0.0.0:9042

environment:
  - USERNAME
  - PASSWORD
  - GATEWAY_URL
  - LISTEN_ADDRESS
```

This allows users to pass sensitive credentials externally via a `.env` file or `stack.env`, without modifying the compose file directly.

## Why this change

- Many users now deploy via GitOps workflows or tools like Portainer
- Tools like Portainer override environment variables from `stack.env` *only if* they are referenced by key name (not if values are set inline)
- This approach:
  - improves security (no secrets in version control)
  - improves maintainability (variables can be injected at runtime)
  - works seamlessly with `docker-compose`, Portainer, and CI/CD pipelines

## Backwards compatibility

✅ The original values are preserved as **comments** for reference and can easily be re-enabled by users unfamiliar with `.env` usage.  
✅ No functionality is changed.  
✅ Existing setups will not break if `.env` is not provided (as Compose will simply set empty values).

## Related

- Fixes an issue encountered when using this project in Portainer with GitOps + stack.env

---

Please let me know if you'd prefer to keep the old block active and have `.env` values override it instead — I'm happy to adjust the PR accordingly.
