### PR TITLE
feat: add FritzBox 5690 Pro v8.25 metrics and DSL metric definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ For lua metrics open UI in browser and check the json files used for the various
 
 For a list of all available metrics, see the dumps below (the format is the same as in the metrics.json file, so it can be used to easily add further metrics to retrieve):
 
+- [FritzBox 5690 Pro v8.26](all_available_metrics_5690_pro_8.25.json)
 - [FritzBox 5690 Pro v8.03](all_available_metrics_5690_pro_8.03.json)
 - [FritzBox 6591 v7.29](all_available_metrics_6591_7.29.json)
 - [FritzBox 6690 v7.57](all_available_metrics_6690_7.57.json)

--- a/all_available_metrics_5690_pro_8.25.json
+++ b/all_available_metrics_5690_pro_8.25.json
@@ -1,0 +1,4707 @@
+[
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "ConfigurationFinished",
+		"result": "A_ARG_TYPE_Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "GetPersistentData",
+		"result": "PersistentData"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_CreateUrlSID",
+		"result": "X_AVM-DE_UrlSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetSupportDataEnable",
+		"result": "X_AVM-DE_SupportDataEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetSupportDataInfo",
+		"result": "X_AVM-DE_SupportDataMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetSupportDataInfo",
+		"result": "X_AVM-DE_SupportDataID"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetSupportDataInfo",
+		"result": "X_AVM-DE_SupportDataTimestamp"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetSupportDataInfo",
+		"result": "X_AVM-DE_SupportDataStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetSupportDataInfo",
+		"result": "X_AVM-DE_SupportDataEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetUserAgreement",
+		"result": "X_AVM-DE_UserAgreed"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetUserAgreement",
+		"result": "X_AVM-DE_TermsOfUseVersion"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_AVM-DE_GetUserAgreement",
+		"result": "X_AVM-DE_TermsOfUsePath"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceConfig:1",
+		"action": "X_GenerateUUID",
+		"result": "UUID"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetDeviceLog",
+		"result": "DeviceLog"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "ManufacturerName"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "ManufacturerOUI"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "ModelName"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "Description"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "ProductClass"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "SerialNumber"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "SoftwareVersion"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "HardwareVersion"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "SpecVersion"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "ProvisioningCode"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "UpTime"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetInfo",
+		"result": "DeviceLog"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "GetSecurityPort",
+		"result": "SecurityPort"
+	},
+	{
+		"service": "urn:dslforum-org:service:DeviceInfo:1",
+		"action": "X_AVM-DE_GetDeviceLogPath",
+		"result": "DeviceLogPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "GetHostNumberOfEntries",
+		"result": "HostNumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetChangeCounter",
+		"result": "X_AVM-DE_ChangeCounter"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetFriendlyName",
+		"result": "X_AVM-DE_FriendlyName"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetHostListPath",
+		"result": "X_AVM-DE_HostListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_FriendlynameMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_FriendlynameMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_HostnameMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_HostnameMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_HostnameAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_DeviceClassUserPossibleValues"
+	},
+	{
+		"service": "urn:dslforum-org:service:Hosts:1",
+		"action": "X_AVM-DE_GetMeshListPath",
+		"result": "X_AVM-DE_MeshListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "GetInfo",
+		"result": "MaxCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "GetInfo",
+		"result": "MinCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_IsDefaultPasswordActive"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "X_AVM-DE_GetAnonymousLogin",
+		"result": "X_AVM-DE_AnonymousLoginEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "X_AVM-DE_GetAnonymousLogin",
+		"result": "X_AVM-DE_ButtonLoginEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "X_AVM-DE_GetCurrentUser",
+		"result": "X_AVM-DE_CurrentUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "X_AVM-DE_GetCurrentUser",
+		"result": "X_AVM-DE_CurrentUserRights"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANConfigSecurity:1",
+		"action": "X_AVM-DE_GetUserList",
+		"result": "X_AVM-DE_UserList"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "MACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "MaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "DuplexMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetStatistics",
+		"result": "Stats.BytesSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetStatistics",
+		"result": "Stats.BytesReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetStatistics",
+		"result": "Stats.PacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+		"action": "GetStatistics",
+		"result": "Stats.PacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetAddressRange",
+		"result": "MinAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetAddressRange",
+		"result": "MaxAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetDNSServers",
+		"result": "DNSServers"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetIPInterfaceNumberOfEntries",
+		"result": "IPInterfaceNumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetIPRoutersList",
+		"result": "IPRouters"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "DHCPServerConfigurable"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "DHCPRelay"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "MinAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "MaxAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "ReservedAddresses"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "DHCPServerEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "DNSServers"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "DomainName"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "IPRouters"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetInfo",
+		"result": "SubnetMask"
+	},
+	{
+		"service": "urn:dslforum-org:service:LANHostConfigManagement:1",
+		"action": "GetSubnetMask",
+		"result": "SubnetMask"
+	},
+	{
+		"service": "urn:dslforum-org:service:Layer3Forwarding:1",
+		"action": "GetDefaultConnectionService",
+		"result": "DefaultConnectionService"
+	},
+	{
+		"service": "urn:dslforum-org:service:Layer3Forwarding:1",
+		"action": "GetForwardNumberOfEntries",
+		"result": "ForwardNumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "URL"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "Username"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "PeriodicInformEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "PeriodicInformInterval"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "PeriodicInformTime"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "ParameterKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "ParameterHash"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "ConnectionRequestURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "ConnectionRequestUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "GetInfo",
+		"result": "UpgradesManaged"
+	},
+	{
+		"service": "urn:dslforum-org:service:ManagementServer:1",
+		"action": "X_AVM-DE_GetTR069FirmwareDownloadEnabled",
+		"result": "TR069FirmwareDownloadEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "NTPServer1"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "NTPServer2"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "CurrentLocalTime"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "LocalTimeZone"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "LocalTimeZoneName"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "DaylightSavingsUsed"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "DaylightSavingsStart"
+	},
+	{
+		"service": "urn:dslforum-org:service:Time:1",
+		"action": "GetInfo",
+		"result": "DaylightSavingsEnd"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "UpgradeAvailable"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "PasswordRequired"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "PasswordUserSelectable"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "WarrantyDate"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_Version"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_DownloadURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_InfoURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_UpdateState"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_BuildType"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_SetupAssistantStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_DoPrepareCGI",
+		"result": "X_AVM-DE_CGI"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_DoPrepareCGI",
+		"result": "X_AVM-DE_SessionID"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_DoUpdate",
+		"result": "UpgradeAvailable"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_DoUpdate",
+		"result": "X_AVM-DE_UpdateState"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_AutoUpdateMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_UpdateTime"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_LastFwVersion"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_InfoURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_Version"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInfo",
+		"result": "X_AVM-DE_UpdateSuccessful"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInternationalConfig",
+		"result": "X_AVM-DE_Language"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInternationalConfig",
+		"result": "X_AVM-DE_Country"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInternationalConfig",
+		"result": "X_AVM-DE_Annex"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInternationalConfig",
+		"result": "X_AVM-DE_LanguageList"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInternationalConfig",
+		"result": "X_AVM-DE_CountryList"
+	},
+	{
+		"service": "urn:dslforum-org:service:UserInterface:1",
+		"action": "X_AVM-DE_GetInternationalConfig",
+		"result": "X_AVM-DE_AnnexList"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "WANAccessType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "Layer1UpstreamMaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "Layer1DownstreamMaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "PhysicalLinkStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "X_AVM-DE_DownstreamCurrentUtilization"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "X_AVM-DE_UpstreamCurrentUtilization"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "X_AVM-DE_DownstreamCurrentMaxSpeed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "X_AVM-DE_UpstreamCurrentMaxSpeed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalBytesReceived",
+		"result": "TotalBytesReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalBytesSent",
+		"result": "TotalBytesSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalPacketsReceived",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalPacketsSent",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+		"action": "X_AVM-DE_GetActiveProvider",
+		"result": "X_AVM-DE_Provider"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "DataPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "UpstreamCurrRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "DownstreamCurrRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "UpstreamMaxRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "DownstreamMaxRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "UpstreamNoiseMargin"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "DownstreamNoiseMargin"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "UpstreamAttenuation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "DownstreamAttenuation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "ATURVendor"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "ATURCountry"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "UpstreamPower"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetInfo",
+		"result": "DownstreamPower"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.ReceiveBlocks"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.TransmitBlocks"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.CellDelin"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.LinkRetrain"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.InitErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.InitTimeouts"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.LossOfFraming"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.ErroredSecs"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.SeverelyErroredSecs"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.FECErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.ATUCFECErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.HECErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.ATUCHECErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.CRCErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "GetStatisticsTotal",
+		"result": "Stats.Total.ATUCCRCErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLDiagnoseInfo",
+		"result": "X_AVM-DE_DSLDiagnoseState"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLDiagnoseInfo",
+		"result": "X_AVM-DE_CableNokDistance"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLDiagnoseInfo",
+		"result": "X_AVM-DE_DSLLastDiagnoseTime"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLDiagnoseInfo",
+		"result": "X_AVM-DE_DSLSignalLossTime"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLDiagnoseInfo",
+		"result": "X_AVM-DE_DSLActive"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLDiagnoseInfo",
+		"result": "X_AVM-DE_DSLSync"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "SNRGds"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "SNRGus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "SNRpsds"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "SNRpsus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "SNRMTds"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "SNRMTus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "LATNds"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "LATNus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "Stats.Total.FECErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "Stats.Total.CRCErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "LinkStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "ModulationType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "CurrentProfile"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "UpstreamCurrRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "DownstreamCurrRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "UpstreamMaxRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "DownstreamMaxRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "UpstreamNoiseMargin"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "DownstreamNoiseMargin"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "UpstreamAttenuation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "DownstreamAttenuation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "ATURVendor"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "ATURCountry"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "UpstreamPower"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+		"action": "X_AVM-DE_GetDSLInfo",
+		"result": "DownstreamPower"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetATMEncapsulation",
+		"result": "ATMEncapsulation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetAutoConfig",
+		"result": "AutoConfig"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetDSLLinkInfo",
+		"result": "LinkType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetDSLLinkInfo",
+		"result": "LinkStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetDestinationAddress",
+		"result": "DestinationAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "LinkStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "LinkType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "DestinationAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "ATMEncapsulation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "AutoConfig"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "ATMQoS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "ATMPeakCellRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetInfo",
+		"result": "ATMSustainableCellRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetStatistics",
+		"result": "ATMTransmittedBlocks"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetStatistics",
+		"result": "ATMReceivedBlocks"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetStatistics",
+		"result": "AAL5CRCErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANDSLLinkConfig:1",
+		"action": "GetStatistics",
+		"result": "ATMCRCErrors"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANEthernetLinkConfig:1",
+		"action": "GetEthernetLinkStatus",
+		"result": "EthernetLinkStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetConnectionTypeInfo",
+		"result": "ConnectionType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetConnectionTypeInfo",
+		"result": "PossibleConnectionTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetExternalIPAddress",
+		"result": "ExternalIPAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "ConnectionStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "PossibleConnectionTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "ConnectionType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "Name"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "Uptime"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "LastConnectionError"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "RSIPAvailable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "NATEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "ExternalIPAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "DNSServers"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "MACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "ConnectionTrigger"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "RouteProtocolRx"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "DNSEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetInfo",
+		"result": "DNSOverrideAllowed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetNATRSIPStatus",
+		"result": "RSIPAvailable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetNATRSIPStatus",
+		"result": "NATEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetPortMappingNumberOfEntries",
+		"result": "PortMappingNumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "ConnectionStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "LastConnectionError"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "Uptime"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANIPConnection:1",
+		"action": "X_GetDNSServers",
+		"result": "DNSServers"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetConnectionTypeInfo",
+		"result": "ConnectionType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetConnectionTypeInfo",
+		"result": "PossibleConnectionTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetExternalIPAddress",
+		"result": "ExternalIPAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "ConnectionStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "PossibleConnectionTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "ConnectionType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "Name"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "Uptime"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "UpstreamMaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "DownstreamMaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "LastConnectionError"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "IdleDisconnectTime"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "RSIPAvailable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "UserName"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "NATEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "ExternalIPAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "DNSServers"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "MACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "ConnectionTrigger"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "LastAuthErrorInfo"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "MaxCharsUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "MinCharsUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "MaxCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "MinCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "TransportType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "RouteProtocolRx"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "PPPoEServiceName"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "RemoteIPAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "PPPoEACName"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "DNSEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetInfo",
+		"result": "DNSOverrideAllowed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetLinkLayerMaxBitRates",
+		"result": "UpstreamMaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetLinkLayerMaxBitRates",
+		"result": "DownstreamMaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetNATRSIPStatus",
+		"result": "RSIPAvailable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetNATRSIPStatus",
+		"result": "NATEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetPortMappingNumberOfEntries",
+		"result": "PortMappingNumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "ConnectionStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "LastConnectionError"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "Uptime"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "GetUserName",
+		"result": "UserName"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "X_AVM-DE_GetAutoDisconnectTimeSpan",
+		"result": "X_AVM-DE_DisconnectPreventionEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "X_AVM-DE_GetAutoDisconnectTimeSpan",
+		"result": "X_AVM-DE_DisconnectPreventionHour"
+	},
+	{
+		"service": "urn:dslforum-org:service:WANPPPConnection:1",
+		"action": "X_GetDNSServers",
+		"result": "DNSServers"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetBSSID",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetBeaconAdvertisement",
+		"result": "BeaconAdvertisementEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetBeaconType",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetBeaconType",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetChannelInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetChannelInfo",
+		"result": "PossibleChannels"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetDefaultWEPKeyIndex",
+		"result": "WEPKeyIndex"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "MaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "MACAddressControlEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "MaxCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "MinCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "MinCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "MaxCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_WLANGlobalEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetSSID",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey0"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey1"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey2"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey3"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetSecurityKeys",
+		"result": "PreSharedKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetSecurityKeys",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "GetTotalAssociations",
+		"result": "TotalAssociations"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetIPTVOptimized",
+		"result": "X_AVM-DE_IPTVoptimize"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightControl"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightTimeControlNoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "AssociatedDeviceMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_ChannelWidth"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SignalStrength"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_Speed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRX"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRXMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_APMLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOList"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANDeviceListPath",
+		"result": "X_AVM-DE_WLANDeviceListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeoutActive"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_Timeout"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeRemain"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_NoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_UserIsolation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_EncryptionMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_LastChangedStamp"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "TrafficMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "ManualSpeed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedDS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedUS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:1",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetBSSID",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetBeaconAdvertisement",
+		"result": "BeaconAdvertisementEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetBeaconType",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetBeaconType",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetChannelInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetChannelInfo",
+		"result": "PossibleChannels"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetDefaultWEPKeyIndex",
+		"result": "WEPKeyIndex"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "MaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "MACAddressControlEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "MaxCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "MinCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "AllowedCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "MinCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "MaxCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "AllowedCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_WLANGlobalEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetSSID",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey0"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey1"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey2"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey3"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetSecurityKeys",
+		"result": "PreSharedKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetSecurityKeys",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "GetTotalAssociations",
+		"result": "TotalAssociations"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetIPTVOptimized",
+		"result": "X_AVM-DE_IPTVoptimize"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightControl"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightTimeControlNoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "AssociatedDeviceMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_ChannelWidth"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SignalStrength"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_Speed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRX"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRXMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_APMLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOList"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANDeviceListPath",
+		"result": "X_AVM-DE_WLANDeviceListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeoutActive"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_Timeout"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeRemain"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_NoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_UserIsolation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_EncryptionMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_LastChangedStamp"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "TrafficMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "ManualSpeed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedDS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedUS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:2",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetBSSID",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetBeaconAdvertisement",
+		"result": "BeaconAdvertisementEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetBeaconType",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetBeaconType",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetChannelInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetChannelInfo",
+		"result": "PossibleChannels"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetDefaultWEPKeyIndex",
+		"result": "WEPKeyIndex"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "MaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "MACAddressControlEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "MaxCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "MinCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "AllowedCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "MinCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "MaxCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "AllowedCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_WLANGlobalEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetSSID",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey0"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey1"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey2"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey3"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetSecurityKeys",
+		"result": "PreSharedKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetSecurityKeys",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "GetTotalAssociations",
+		"result": "TotalAssociations"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetIPTVOptimized",
+		"result": "X_AVM-DE_IPTVoptimize"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightControl"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightTimeControlNoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "AssociatedDeviceMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_ChannelWidth"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SignalStrength"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_Speed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRX"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRXMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_APMLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOList"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANDeviceListPath",
+		"result": "X_AVM-DE_WLANDeviceListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeoutActive"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_Timeout"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeRemain"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_NoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_UserIsolation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_EncryptionMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_LastChangedStamp"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "TrafficMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "ManualSpeed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedDS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedUS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:3",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetBSSID",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetBasBeaconSecurityProperties",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetBeaconAdvertisement",
+		"result": "BeaconAdvertisementEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetBeaconType",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetBeaconType",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetChannelInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetChannelInfo",
+		"result": "PossibleChannels"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetChannelInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetDefaultWEPKeyIndex",
+		"result": "WEPKeyIndex"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "MaxBitRate"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_PossibleBeaconTypes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "MACAddressControlEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "BasicEncryptionModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "BasicAuthenticationMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "MaxCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "MinCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "AllowedCharsSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "MinCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "MaxCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "AllowedCharsPSK"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetInfo",
+		"result": "X_AVM-DE_WLANGlobalEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetPacketStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetSSID",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey0"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey1"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey2"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetSecurityKeys",
+		"result": "WEPKey3"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetSecurityKeys",
+		"result": "PreSharedKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetSecurityKeys",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetStatistics",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetStatistics",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "GetTotalAssociations",
+		"result": "TotalAssociations"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetIPTVOptimized",
+		"result": "X_AVM-DE_IPTVoptimize"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightControl"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetNightControl",
+		"result": "NightTimeControlNoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "AssociatedDeviceMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Channel"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "Standard"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_AutoChannelEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_ChannelWidth"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SignalStrength"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_Speed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRX"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_SpeedRXMax"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_APMLDMACAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOModes"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANConnectionInfo",
+		"result": "X_AVM-DE_MLOList"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANDeviceListPath",
+		"result": "X_AVM-DE_WLANDeviceListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_APType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_FrequencyBand"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeoutActive"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_Timeout"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_TimeRemain"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_NoForcedOff"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_UserIsolation"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_EncryptionMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANExtInfo",
+		"result": "X_AVM-DE_LastChangedStamp"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BeaconType"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "KeyPassphrase"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "SSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "BSSID"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "TrafficMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "ManualSpeed"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedDS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWLANHybridMode",
+		"result": "MaxSpeedUS"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:WLANConfiguration:4",
+		"action": "X_AVM-DE_GetWPSInfo",
+		"result": "X_AVM-DE_WPSStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "SubnetMask"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "IPAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "ExternalIPAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "ExternalIPv6Address"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "RemoteAccessDDNSEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "RemoteAccessDDNSDomain"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "MyFritzEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetAppRemoteInfo",
+		"result": "MyFritzDynDNSName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "ConfigRight"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "AppRight"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "NasRight"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "PhoneRight"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "DialRight"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "HomeautoRight"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "InternetRights"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetConfig",
+		"result": "AccessFromInternet"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsAppId"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsAppId"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsAppId"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsAppDisplayName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsAppDisplayName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsAppUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsAppUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsAppUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsAppPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsAppPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsAppPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsIPSecIdentifier"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsIPSecIdentifier"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsIPSecIdentifier"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsCryptAlgos"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsAppAVMAddress"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsFilter"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsFilter"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsFilter"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsIPSecPreSharedKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsIPSecPreSharedKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsIPSecPreSharedKey"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsIPSecXauthUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsIPSecXauthUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsIPSecXauthUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MinCharsIPSecXauthPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "MaxCharsIPSecXauthPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_AppSetup:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsIPSecXauthPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Auth:1",
+		"action": "GetInfo",
+		"result": "Enabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Auth:1",
+		"action": "GetState",
+		"result": "State"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Dect:1",
+		"action": "GetDectListPath",
+		"result": "DectListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Dect:1",
+		"action": "GetNumberOfDectEntries",
+		"result": "NumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Filelinks:1",
+		"action": "GetFilelinkListPath",
+		"result": "FilelinkListPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Filelinks:1",
+		"action": "GetNumberOfFilelinkEntries",
+		"result": "NumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Homeauto:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsAIN"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Homeauto:1",
+		"action": "GetInfo",
+		"result": "MaxCharsAIN"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Homeauto:1",
+		"action": "GetInfo",
+		"result": "MinCharsAIN"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Homeauto:1",
+		"action": "GetInfo",
+		"result": "MaxCharsDeviceName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Homeauto:1",
+		"action": "GetInfo",
+		"result": "MinCharsDeviceName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Homeplug:1",
+		"action": "GetNumberOfDeviceEntries",
+		"result": "NumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_HostFilter:1",
+		"action": "GetFilterProfiles",
+		"result": "FilterProfileList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_HostFilter:1",
+		"action": "MarkTicket",
+		"result": "TicketID"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_MyFritz:1",
+		"action": "GetInfo",
+		"result": "Enabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_MyFritz:1",
+		"action": "GetInfo",
+		"result": "DeviceRegistered"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_MyFritz:1",
+		"action": "GetInfo",
+		"result": "DynDNSName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_MyFritz:1",
+		"action": "GetInfo",
+		"result": "Port"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_MyFritz:1",
+		"action": "GetInfo",
+		"result": "State"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_MyFritz:1",
+		"action": "GetInfo",
+		"result": "Email"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_MyFritz:1",
+		"action": "GetNumberOfServices",
+		"result": "NumberOfServices"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetCallBarringList",
+		"result": "PhonebookURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetCallList",
+		"result": "CallListURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetDECTHandsetList",
+		"result": "DectIDList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetDeflections",
+		"result": "DeflectionList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetInfo",
+		"result": "LastConnect"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetInfo",
+		"result": "Url"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetInfo",
+		"result": "ServiceId"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetInfo",
+		"result": "Username"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetInfo",
+		"result": "Name"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetNumberOfDeflections",
+		"result": "NumberOfDeflections"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetNumberOfEntries",
+		"result": "OnTelNumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_OnTel:1",
+		"action": "GetPhonebookList",
+		"result": "PhonebookList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "Enabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "ProviderName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "UpdateURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "Domain"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "StatusIPv4"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "StatusIPv6"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "Username"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "Mode"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "ServerIPv4"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSInfo",
+		"result": "ServerIPv6"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetDDNSProviders",
+		"result": "ProviderList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetInfo",
+		"result": "Enabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetInfo",
+		"result": "Port"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetInfo",
+		"result": "Username"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetInfo",
+		"result": "LetsEncryptEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_RemoteAccess:1",
+		"action": "GetInfo",
+		"result": "LetsEncryptState"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "EnableTcp"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "EnableUdp"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "EnableUdpBidirect"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "WANEnableTcp"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "WANEnableUdp"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "PortTcp"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "PortUdp"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetInfo",
+		"result": "PortUdpBidirect"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetStatistics",
+		"result": "ByteCount"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetStatistics",
+		"result": "KbitsCurrent"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetStatistics",
+		"result": "KbitsAvg"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetStatistics",
+		"result": "PacketCount"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetStatistics",
+		"result": "PPSCurrent"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Speedtest:1",
+		"action": "GetStatistics",
+		"result": "PPSAvg"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetInfo",
+		"result": "FTPEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetInfo",
+		"result": "FTPStatus"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetInfo",
+		"result": "SMBEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetInfo",
+		"result": "FTPWANEnable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetInfo",
+		"result": "FTPWANSSLOnly"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetInfo",
+		"result": "FTPWANPort"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetUserInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetUserInfo",
+		"result": "Username"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "GetUserInfo",
+		"result": "X_AVM-DE_NetworkAccessReadOnly"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "RequestFTPServerWAN",
+		"result": "FTPWANPort"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_Storage:1",
+		"action": "RequestFTPServerWAN",
+		"result": "FTPWANLifetime"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_TAM:1",
+		"action": "GetList",
+		"result": "TAMList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_UPnP:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_UPnP:1",
+		"action": "GetInfo",
+		"result": "UPnPMediaServer"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsEndpointID"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsEndpointID"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "AllowedCharsEndpointID"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsHostname"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsHostname"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsPath"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsMQTTControllerTopic"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsMQTTControllerTopic"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsMQTTResponseTopic"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsMQTTResponseTopic"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsMQTTClientID"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsMQTTClientID"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MinCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "MaxCharsPassword"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetInfo",
+		"result": "USPMyFRITZEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetUSPControllerNumberOfEntries",
+		"result": "USPControllerNumberOfEntries"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_USPController:1",
+		"action": "GetUSPMyFRITZEnable",
+		"result": "USPMyFRITZEnabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "OpticalSignalLevel"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "LowerOpticalThreshold"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "UpperOpticalThreshold"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "TransmitOpticalLevel"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "LowerTransmitPowerThreshold"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "UpperTransmitPowerThreshold"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "SFPVendor"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "SFPPartNumber"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "SFPSerialNumber"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "SFPType"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "TXWaveLength"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfo",
+		"result": "FiberMode"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfoGPON",
+		"result": "GPONSerial"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfoGPON",
+		"result": "PONId"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfoGPON",
+		"result": "ONUId"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfoGPON",
+		"result": "UNIType"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetInfoGPON",
+		"result": "GEMPortCount"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "BytesSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "BytesReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "PacketsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "PacketsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "PacketErrorsSent"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "PacketErrorsReceived"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "PacketsMulticast"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "ConnectionRateDown"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "ConnectionRateUp"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "BestTrainState"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "Resyncs"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANFiber:1",
+		"action": "GetStatistics",
+		"result": "MinutesInShowtime"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetAccessTechnology",
+		"result": "AccessTechnology"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetAccessTechnology",
+		"result": "PossibleAccessTechnology"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetAccessTechnology",
+		"result": "CurrentAccessTechnology"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetBandCapabilities",
+		"result": "BandCapabilitiesLTE"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetBandCapabilities",
+		"result": "BandCapabilities5GNSA"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetBandCapabilities",
+		"result": "BandCapabilities5GSA"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetEnabledBandCapabilities",
+		"result": "BandCapabilitiesLTE"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetEnabledBandCapabilities",
+		"result": "BandCapabilities5GNSA"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetEnabledBandCapabilities",
+		"result": "BandCapabilities5GSA"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfo",
+		"result": "Enabled"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfo",
+		"result": "Status"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfo",
+		"result": "PINFailureCount"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfo",
+		"result": "PUKFailureCount"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "SerialNumber"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "EnableVoIPPDN"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "PPPUsername"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "PPPUsernameVoIP"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "PPPAuthProtocol"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "PPPAuthProtocolVoIP"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "SoftwareVersion"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "Uptime"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "PDN1_MTU"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "PDN2_MTU"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "IMSI"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "APN_VoIP"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "APN"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "Roaming"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "CurrentAccessTechnology"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "SignalRSRP0"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "SignalRSRP1"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetInfoEx",
+		"result": "CellList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetPreferredAccessTechnology",
+		"result": "PreferredAccessTechnology"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WANMobileConnection:1",
+		"action": "GetPreferredAccessTechnology",
+		"result": "PossiblePreferredAccessTechnology"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WebDAVClient:1",
+		"action": "GetInfo",
+		"result": "Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WebDAVClient:1",
+		"action": "GetInfo",
+		"result": "HostURL"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WebDAVClient:1",
+		"action": "GetInfo",
+		"result": "Username"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_AVM-DE_WebDAVClient:1",
+		"action": "GetInfo",
+		"result": "MountpointName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetExistingVoIPNumbers",
+		"result": "ExistingVoIPNumbers"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfo",
+		"result": "FaxT38Enable"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfo",
+		"result": "VoiceCoding"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPNumberMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPNumberMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPNumberAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPUsernameMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPUsernameMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPUsernameAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPPasswordMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPPasswordMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPPasswordAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPRegistrarMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPRegistrarMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPRegistrarAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPSTUNServerMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPSTUNServerMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "VoIPSTUNServerAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "X_AVM-DE_ClientUsernameMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "X_AVM-DE_ClientUsernameMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "X_AVM-DE_ClientUsernameAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "X_AVM-DE_ClientPasswordMinChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "X_AVM-DE_ClientPasswordMaxChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetInfoEx",
+		"result": "X_AVM-DE_ClientPasswordAllowedChars"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetMaxVoIPNumbers",
+		"result": "MaxVoIPNumbers"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetVoIPCommonAreaCode",
+		"result": "VoIPAreaCode"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "GetVoIPCommonCountryCode",
+		"result": "VoIPCountryCode"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_DialGetConfig",
+		"result": "X_AVM-DE_PhoneName"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetClients",
+		"result": "X_AVM-DE_ClientList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetNumberOfAlarmClocks",
+		"result": "X_AVM-DE_NumberOfAlarmClocks"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetNumberOfClients",
+		"result": "X_AVM-DE_NumberOfClients"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetNumberOfNumbers",
+		"result": "NumberOfNumbers"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetNumbers",
+		"result": "NumberList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetVoIPAccounts",
+		"result": "X_AVM-DE_VoIPAccountList"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetVoIPCommonAreaCode",
+		"result": "X_AVM-DE_OKZ"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetVoIPCommonAreaCode",
+		"result": "X_AVM-DE_OKZPrefix"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetVoIPCommonCountryCode",
+		"result": "X_AVM-DE_LKZ"
+	},
+	{
+		"service": "urn:dslforum-org:service:X_VoIP:1",
+		"action": "X_AVM-DE_GetVoIPCommonCountryCode",
+		"result": "X_AVM-DE_LKZPrefix"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "ByteSendRate"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "ByteReceiveRate"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "PacketSendRate"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "PacketReceiveRate"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "TotalBytesSent"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "TotalBytesReceived"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "AutoDisconnectTime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "IdleDisconnectTime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "DNSServer1"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "DNSServer2"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "VoipDNSServer1"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "VoipDNSServer2"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "UpnpControlEnabled"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "RoutedBridgedModeBoth"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "X_AVM_DE_TotalBytesSent64"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "X_AVM_DE_TotalBytesReceived64"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "X_AVM_DE_WANAccessType"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "X_AVM_DE_Layer1UpstreamMaxBitRate64"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetAddonInfos",
+		"result": "X_AVM_DE_Layer1DownstreamMaxBitRate64"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "WANAccessType"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "Layer1UpstreamMaxBitRate"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "Layer1DownstreamMaxBitRate"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetCommonLinkProperties",
+		"result": "PhysicalLinkStatus"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalBytesReceived",
+		"result": "TotalBytesReceived"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalBytesSent",
+		"result": "TotalBytesSent"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalPacketsReceived",
+		"result": "TotalPacketsReceived"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "GetTotalPacketsSent",
+		"result": "TotalPacketsSent"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "X_AVM_DE_GetDsliteStatus",
+		"result": "X_AVM_DE_DsliteStatus"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "X_AVM_DE_GetIPTVInfos",
+		"result": "X_AVM_DE_IPTV_Enabled"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "X_AVM_DE_GetIPTVInfos",
+		"result": "X_AVM_DE_IPTV_Provider"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+		"action": "X_AVM_DE_GetIPTVInfos",
+		"result": "X_AVM_DE_IPTV_URL"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANDSLLinkConfig:1",
+		"action": "GetATMEncapsulation",
+		"result": "ATMEncapsulation"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANDSLLinkConfig:1",
+		"action": "GetAutoConfig",
+		"result": "AutoConfig"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANDSLLinkConfig:1",
+		"action": "GetDSLLinkInfo",
+		"result": "LinkType"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANDSLLinkConfig:1",
+		"action": "GetDSLLinkInfo",
+		"result": "LinkStatus"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANDSLLinkConfig:1",
+		"action": "GetDestinationAddress",
+		"result": "DestinationAddress"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANDSLLinkConfig:1",
+		"action": "GetFCSPreserved",
+		"result": "FCSPreserved"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANDSLLinkConfig:1",
+		"action": "GetModulationType",
+		"result": "ModulationType"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetAutoDisconnectTime",
+		"result": "AutoDisconnectTime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetConnectionTypeInfo",
+		"result": "ConnectionType"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetConnectionTypeInfo",
+		"result": "PossibleConnectionTypes"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetExternalIPAddress",
+		"result": "ExternalIPAddress"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetIdleDisconnectTime",
+		"result": "IdleDisconnectTime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetNATRSIPStatus",
+		"result": "RSIPAvailable"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetNATRSIPStatus",
+		"result": "NATEnabled"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "ConnectionStatus"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "LastConnectionError"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "GetStatusInfo",
+		"result": "Uptime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetDNSServer",
+		"result": "IPv4DNSServer1"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetDNSServer",
+		"result": "IPv4DNSServer2"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetExternalIPv6Address",
+		"result": "ExternalIPv6Address"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetExternalIPv6Address",
+		"result": "PrefixLength"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetExternalIPv6Address",
+		"result": "ValidLifetime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetExternalIPv6Address",
+		"result": "PreferedLifetime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6DNSServer",
+		"result": "IPv6DNSServer1"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6DNSServer",
+		"result": "ValidLifetime1"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6DNSServer",
+		"result": "IPv6DNSServer2"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6DNSServer",
+		"result": "ValidLifetime2"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6Prefix",
+		"result": "IPv6Prefix"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6Prefix",
+		"result": "PrefixLength"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6Prefix",
+		"result": "ValidLifetime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+		"action": "X_AVM_DE_GetIPv6Prefix",
+		"result": "PreferedLifetime"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPv6FirewallControl:1",
+		"action": "GetFirewallStatus",
+		"result": "FirewallEnabled"
+	},
+	{
+		"service": "urn:schemas-upnp-org:service:WANIPv6FirewallControl:1",
+		"action": "GetFirewallStatus",
+		"result": "InboundPinholeAllowed"
+	}
+]

--- a/metrics-lua_5690_pro.json
+++ b/metrics-lua_5690_pro.json
@@ -1,0 +1,279 @@
+{
+    "labelRenames": [
+        {
+            "matchRegex": "(?i)^(?:prozessor|processore)",
+            "renameLabel": "CPU"
+        },
+        {
+            "matchRegex": "(?i)^(?:system|sistema)",
+            "renameLabel": "System"
+        },
+        {
+            "matchRegex": "(?i)DSL",
+            "renameLabel": "DSL"
+        },
+        {
+            "matchRegex": "(?i)Glasfaser",
+            "renameLabel": "Fiber"
+        },
+        {
+            "matchRegex": "(?i)FON",
+            "renameLabel": "Phone"
+        },
+        {
+            "matchRegex": "(?i)WLAN",
+            "renameLabel": "WLAN"
+        },
+        {
+            "matchRegex": "(?i)USB",
+            "renameLabel": "USB"
+        },
+        {
+            "matchRegex": "(?i)Speicher.*FRITZ",
+            "renameLabel": "Internal eStorage"
+        }
+    ],
+    "metrics": [
+        {
+            "path": "data.lua",
+            "params": "page=energy",
+            "resultPath": "data.drain.*",
+            "resultKey": "actPerc",
+            "promDesc": {
+                "fqName": "gateway_data_energy_consumption",
+                "help": "percentage of energy consumed from data.lua?page=energy",
+                "varLabels": [
+                    "gateway", "name"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=energy",
+            "resultPath": "data.drain.*.lan.*",
+            "resultKey": "class",
+            "okValue": "green",
+            "promDesc": {
+                "fqName": "gateway_data_energy_lan_status",
+                "help": "status of LAN connection from data.lua?page=energy (1 = up)",
+                "varLabels": [
+                    "gateway", "name"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=ecoStat",
+            "resultPath": "data.cputemp.series.0",
+            "resultKey": "-1",
+            "promDesc": {
+                "fqName": "gateway_data_ecostat_cputemp",
+                "help": "cpu temperature from data.lua?page=ecoStat",
+                "varLabels": [
+                    "gateway"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=ecoStat",
+            "resultPath": "data.cpuutil.series.0",
+            "resultKey": "-1",
+            "promDesc": {
+                "fqName": "gateway_data_ecostat_cpuutil",
+                "help": "percentage of cpu utilization from data.lua?page=ecoStat",
+                "varLabels": [
+                    "gateway"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=ecoStat",
+            "resultPath": "data.ramusage.series.0",
+            "resultKey": "-1",
+            "promDesc": {
+                "fqName": "gateway_data_ecostat_ramusage",
+                "help": "percentage of RAM utilization from data.lua?page=ecoStat",
+                "varLabels": [
+                    "gateway"
+                ],
+                "fixedLabels": {
+                    "ram_type" : "Fixed"
+                }
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=ecoStat",
+            "resultPath": "data.ramusage.series.1",
+            "resultKey": "-1",
+            "promDesc": {
+                "fqName": "gateway_data_ecostat_ramusage",
+                "help": "percentage of RAM utilization from data.lua?page=ecoStat",
+                "varLabels": [
+                    "gateway"
+                ],
+                "fixedLabels": {
+                    "ram_type" : "Dynamic"
+                }
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=ecoStat",
+            "resultPath": "data.ramusage.series.2",
+            "resultKey": "-1",
+            "promDesc": {
+                "fqName": "gateway_data_ecostat_ramusage",
+                "help": "percentage of RAM utilization from data.lua?page=ecoStat",
+                "varLabels": [
+                    "gateway"
+                ],
+                "fixedLabels": {
+                    "ram_type" : "Free"
+                }
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=usbOv",
+            "resultPath": "data.usbOverview.devices.*",
+            "resultKey": "partitions.0.totalStorageInBytes",
+            "promDesc": {
+                "fqName": "gateway_data_usb_storage_total",
+                "help": "total storage in bytes from data.lua?page=usbOv",
+                "varLabels": [
+                    "gateway", "deviceType", "deviceName"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=usbOv",
+            "resultPath": "data.usbOverview.devices.*",
+            "resultKey": "partitions.0.usedStorageInBytes",
+            "promDesc": {
+                "fqName": "gateway_data_usb_storage_used",
+                "help": "used storage in bytes from data.lua?page=usbOv",
+                "varLabels": [
+                    "gateway", "deviceType", "deviceName"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=dslStat",
+            "resultPath": "data.negotiatedValues.2",
+            "resultKey": "val.0.ds",
+            "promDesc": {
+                "fqName": "gateway_dsl_line_capacity_kbps",
+                "help": "DSL line capacity (Leitungskapazitaet) in kbit/s from data.lua?page=dslStat (index-based, re-verify after FritzOS updates)",
+                "varLabels": [
+                    "gateway"
+                ],
+                "fixedLabels": {
+                    "direction": "Down"
+                }
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=dslStat",
+            "resultPath": "data.negotiatedValues.2",
+            "resultKey": "val.0.us",
+            "promDesc": {
+                "fqName": "gateway_dsl_line_capacity_kbps",
+                "help": "DSL line capacity (Leitungskapazitaet) in kbit/s from data.lua?page=dslStat (index-based, re-verify after FritzOS updates)",
+                "varLabels": [
+                    "gateway"
+                ],
+                "fixedLabels": {
+                    "direction": "Up"
+                }
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 300
+        },
+        {
+            "path": "data.lua",
+            "params": "page=dslStat",
+            "resultPath": "data.negotiatedValues.14",
+            "resultKey": "val.0",
+            "promDesc": {
+                "fqName": "gateway_dsl_line_length_meter",
+                "help": "approximate DSL line length in meters from data.lua?page=dslStat (index-based, re-verify after FritzOS updates)",
+                "varLabels": [
+                    "gateway"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 3600
+        },
+        {
+            "path": "data.lua",
+            "params": "page=fiberFiber",
+            "resultPath": "data.sfpProperties.0",
+            "resultKey": "val",
+            "promDesc": {
+                "fqName": "gateway_fiber_sfp_temperature_celsius",
+                "help": "SFP module internal temperature in Celsius from data.lua?page=fiberFiber",
+                "varLabels": [
+                    "gateway"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 60
+        },
+        {
+            "path": "data.lua",
+            "params": "page=fiberFiber",
+            "resultPath": "data.sfpProperties.3",
+            "resultKey": "val",
+            "promDesc": {
+                "fqName": "gateway_fiber_sfp_tx_power_dbm",
+                "help": "SFP module transmit power in dBm from data.lua?page=fiberFiber",
+                "varLabels": [
+                    "gateway"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 60
+        },
+        {
+            "path": "data.lua",
+            "params": "page=fiberFiber",
+            "resultPath": "data.sfpProperties.4",
+            "resultKey": "val",
+            "promDesc": {
+                "fqName": "gateway_fiber_sfp_rx_power_dbm",
+                "help": "SFP module receive power in dBm from data.lua?page=fiberFiber",
+                "varLabels": [
+                    "gateway"
+                ]
+            },
+            "promType": "GaugeValue",
+            "cacheEntryTTL": 60
+        }
+    ]
+}

--- a/metrics_5690_pro.json
+++ b/metrics_5690_pro.json
@@ -1,0 +1,793 @@
+[
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetTotalPacketsReceived",
+    "result": "TotalPacketsReceived",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Received",
+        "unit": "Packets",
+        "interface": "WAN"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetTotalPacketsSent",
+    "result": "TotalPacketsSent",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Sent",
+        "unit": "Packets",
+        "interface": "WAN"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetAddonInfos",
+    "result": "TotalBytesReceived",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Received",
+        "unit": "Bytes",
+        "interface": "WAN"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetAddonInfos",
+    "result": "TotalBytesSent",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Sent",
+        "unit": "Bytes",
+        "interface": "WAN"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetAddonInfos",
+    "result": "ByteSendRate",
+    "promDesc": {
+      "fqName": "gateway_traffic_rate",
+      "help": "traffic rate on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Sent",
+        "unit": "Bytes",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetAddonInfos",
+    "result": "ByteReceiveRate",
+    "promDesc": {
+      "fqName": "gateway_traffic_rate",
+      "help": "traffic rate on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Received",
+        "unit": "Bytes",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetCommonLinkProperties",
+    "result": "Layer1UpstreamMaxBitRate",
+    "promDesc": {
+      "fqName": "gateway_max_bitrate",
+      "help": "max bitrate on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Up",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetCommonLinkProperties",
+    "result": "Layer1DownstreamMaxBitRate",
+    "promDesc": {
+      "fqName": "gateway_max_bitrate",
+      "help": "max bitrate on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Down",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetCommonLinkProperties",
+    "result": "PhysicalLinkStatus",
+    "okValue": "Up",
+    "promDesc": {
+      "fqName": "gateway_connection_status",
+      "help": "Connection status (Connected = 1)",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "connection": "Physical Link",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetTotalPacketsReceived",
+    "result": "TotalPacketsReceived",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Received",
+        "unit": "Packets",
+        "interface": "DSL"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetTotalPacketsSent",
+    "result": "TotalPacketsSent",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Sent",
+        "unit": "Packets",
+        "interface": "DSL"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetCommonLinkProperties",
+    "result": "Layer1UpstreamMaxBitRate",
+    "promDesc": {
+      "fqName": "gateway_max_bitrate",
+      "help": "max bitrate on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Up",
+        "interface": "DSL"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetCommonLinkProperties",
+    "result": "Layer1DownstreamMaxBitRate",
+    "promDesc": {
+      "fqName": "gateway_max_bitrate",
+      "help": "max bitrate on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Down",
+        "interface": "DSL"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANCommonInterfaceConfig:1",
+    "action": "GetCommonLinkProperties",
+    "result": "PhysicalLinkStatus",
+    "okValue": "Up",
+    "promDesc": {
+      "fqName": "gateway_connection_status",
+      "help": "Connection status (Connected = 1)",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "connection": "Physical Link",
+        "interface": "DSL"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+    "action": "GetStatusInfo",
+    "result": "ConnectionStatus",
+    "okValue": "Connected",
+    "promDesc": {
+      "fqName": "gateway_connection_status",
+      "help": "Connection status (Connected = 1)",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "connection": "IP",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:schemas-upnp-org:service:WANIPConnection:1",
+    "action": "GetStatusInfo",
+    "result": "Uptime",
+    "promDesc": {
+      "fqName": "gateway_connection_uptime_seconds",
+      "help": "Connection uptime",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "connection": "IP",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANPPPConnection:1",
+    "action": "GetInfo",
+    "result": "ConnectionStatus",
+    "okValue": "Connected",
+    "promDesc": {
+      "fqName": "gateway_wan_connection_status",
+      "help": "WAN Connection status (Connected = 1)",
+      "varLabels": [
+        "gateway",
+        "ConnectionType",
+        "ExternalIPAddress",
+        "MACAddress"
+      ],
+      "fixedLabels": {
+        "connection": "PPP",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANPPPConnection:1",
+    "action": "GetInfo",
+    "result": "Uptime",
+    "promDesc": {
+      "fqName": "gateway_connection_uptime_seconds",
+      "help": "Connection uptime",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "connection": "PPP",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANPPPConnection:1",
+    "action": "GetInfo",
+    "result": "UpstreamMaxBitRate",
+    "promDesc": {
+      "fqName": "gateway_connection_max_bitrate",
+      "help": "connection max bitrate",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Up",
+        "connection": "PPP",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANPPPConnection:1",
+    "action": "GetInfo",
+    "result": "DownstreamMaxBitRate",
+    "promDesc": {
+      "fqName": "gateway_connection_max_bitrate",
+      "help": "connection max bitrate",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Down",
+        "connection": "PPP",
+        "interface": "WAN"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WLANConfiguration:1",
+    "action": "GetTotalAssociations",
+    "result": "TotalAssociations",
+    "promDesc": {
+      "fqName": "gateway_wlan_current_connections",
+      "help": "current WLAN connections",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "wlan": "2.4 GHz"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WLANConfiguration:2",
+    "action": "GetTotalAssociations",
+    "result": "TotalAssociations",
+    "promDesc": {
+      "fqName": "gateway_wlan_current_connections",
+      "help": "current WLAN connections",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "wlan": "5 Ghz"
+      }
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WLANConfiguration:1",
+    "action": "GetInfo",
+    "result": "Status",
+    "okValue": "Up",
+    "promDesc": {
+      "fqName": "gateway_wlan_status",
+      "help": "WLAN status (Enabled = 1)",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "wlan": "2.4 Ghz"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WLANConfiguration:2",
+    "action": "GetInfo",
+    "result": "Status",
+    "okValue": "Up",
+    "promDesc": {
+      "fqName": "gateway_wlan_status",
+      "help": "WLAN status (Enabled = 1)",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "wlan": "5 Ghz"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:DeviceInfo:1",
+    "action": "GetInfo",
+    "result": "UpTime",
+    "promDesc": {
+      "fqName": "gateway_uptime_seconds",
+      "help": "gateway uptime",
+      "varLabels": [
+        "gateway",
+        "Description"
+      ]
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:DeviceInfo:1",
+    "action": "GetInfo",
+    "result": "ModelName",
+    "promDesc": {
+      "fqName": "gateway_device_modelname",
+      "help": "gateway device model name",
+      "varLabels": [
+        "gateway",
+        "Description",
+        "ModelName",
+        "ProductClass",
+        "SoftwareVersion",
+        "HardwareVersion"
+      ]
+    },
+    "promType": "GaugeValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+    "action": "GetStatistics",
+    "result": "Stats.BytesSent",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Sent",
+        "unit": "Bytes",
+        "interface": "LAN"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:LANEthernetInterfaceConfig:1",
+    "action": "GetStatistics",
+    "result": "Stats.BytesReceived",
+    "promDesc": {
+      "fqName": "gateway_traffic",
+      "help": "traffic on gateway interface",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Received",
+        "unit": "Bytes",
+        "interface": "LAN"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:Hosts:1",
+    "action": "GetGenericHostEntry",
+    "actionArgument": {
+      "name": "NewIndex",
+      "isIndex": true,
+      "providerAction": "GetHostNumberOfEntries",
+      "value": "HostNumberOfEntries"
+    },
+    "result": "Active",
+    "promDesc": {
+      "fqName": "gateway_host_active",
+      "help": "is host currently active",
+      "varLabels": [
+        "gateway",
+        "IPAddress",
+        "MACAddress",
+        "InterfaceType",
+        "HostName"
+      ]
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:X_AVM-DE_Dect:1",
+    "action": "GetGenericDectEntry",
+    "actionArgument": {
+      "name": "NewIndex",
+      "isIndex": true,
+      "providerAction": "GetNumberOfDectEntries",
+      "value": "NumberOfEntries"
+    },
+    "result": "Active",
+    "promDesc": {
+      "fqName": "gateway_dect_active",
+      "help": "is dect device currently active",
+      "varLabels": [
+        "gateway",
+        "ID",
+        "Name",
+        "Model"
+      ]
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 120
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "Status",
+    "okValue": "Up",
+    "promDesc": {
+      "fqName": "gateway_dsl_status",
+      "help": "DSL line status (Up = 1)",
+      "varLabels": [
+        "gateway"
+      ]
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "DownstreamCurrRate",
+    "promDesc": {
+      "fqName": "gateway_dsl_current_rate_kbps",
+      "help": "DSL current sync rate in kbit/s",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Down"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "UpstreamCurrRate",
+    "promDesc": {
+      "fqName": "gateway_dsl_current_rate_kbps",
+      "help": "DSL current sync rate in kbit/s",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Up"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "DownstreamMaxRate",
+    "promDesc": {
+      "fqName": "gateway_dsl_max_rate_kbps",
+      "help": "DSL maximum attainable rate in kbit/s",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Down"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "UpstreamMaxRate",
+    "promDesc": {
+      "fqName": "gateway_dsl_max_rate_kbps",
+      "help": "DSL maximum attainable rate in kbit/s",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Up"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "DownstreamNoiseMargin",
+    "promDesc": {
+      "fqName": "gateway_dsl_noise_margin_decibel_tenth",
+      "help": "DSL noise margin in 0.1 dB",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Down"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "UpstreamNoiseMargin",
+    "promDesc": {
+      "fqName": "gateway_dsl_noise_margin_decibel_tenth",
+      "help": "DSL noise margin in 0.1 dB",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Up"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "DownstreamAttenuation",
+    "promDesc": {
+      "fqName": "gateway_dsl_attenuation_decibel_tenth",
+      "help": "DSL line attenuation in 0.1 dB",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Down"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetInfo",
+    "result": "UpstreamAttenuation",
+    "promDesc": {
+      "fqName": "gateway_dsl_attenuation_decibel_tenth",
+      "help": "DSL line attenuation in 0.1 dB",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "direction": "Up"
+      }
+    },
+    "promType": "GaugeValue",
+    "cacheEntryTTL": 60
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetStatisticsTotal",
+    "result": "Stats.Total.CRCErrors",
+    "promDesc": {
+      "fqName": "gateway_dsl_errors_total",
+      "help": "DSL errors since line start",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "type": "CRC"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetStatisticsTotal",
+    "result": "Stats.Total.FECErrors",
+    "promDesc": {
+      "fqName": "gateway_dsl_errors_total",
+      "help": "DSL errors since line start",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "type": "FEC"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetStatisticsTotal",
+    "result": "Stats.Total.HECErrors",
+    "promDesc": {
+      "fqName": "gateway_dsl_errors_total",
+      "help": "DSL errors since line start",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "type": "HEC"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetStatisticsTotal",
+    "result": "Stats.Total.ErroredSecs",
+    "promDesc": {
+      "fqName": "gateway_dsl_errored_seconds_total",
+      "help": "DSL seconds with errors since line start",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "severity": "ES"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetStatisticsTotal",
+    "result": "Stats.Total.SeverelyErroredSecs",
+    "promDesc": {
+      "fqName": "gateway_dsl_errored_seconds_total",
+      "help": "DSL seconds with errors since line start",
+      "varLabels": [
+        "gateway"
+      ],
+      "fixedLabels": {
+        "severity": "SES"
+      }
+    },
+    "promType": "CounterValue"
+  },
+  {
+    "service": "urn:dslforum-org:service:WANDSLInterfaceConfig:1",
+    "action": "GetStatisticsTotal",
+    "result": "Stats.Total.LinkRetrain",
+    "promDesc": {
+      "fqName": "gateway_dsl_link_retrain_total",
+      "help": "DSL link retrains (resyncs) since line start",
+      "varLabels": [
+        "gateway"
+      ]
+    },
+    "promType": "CounterValue"
+  }
+]


### PR DESCRIPTION
Adds FritzBox 5690 Pro (FritzOS 8.25) support files:

- `all_available_metrics_5690_pro_8.25.json`: dump via `-test -json-out` from a live box (additions only compared to the 8.03 dump, nothing removed)
- `metrics_5690_pro.json`: default `metrics.json` plus `WANDSLInterfaceConfig` DSL metrics (sync/max rates, SNR margin, attenuation, CRC/FEC/HEC totals, ES/SES, link retrains) — verified against the live box on a DSL uplink
- `metrics-lua_5690_pro.json`: default `metrics-lua.json` plus Lua-only DSL values (line capacity, line length; `data.lua?page=dslStat` indices verified via `-testLua` on 8.25) and SFP fiber metrics taken from `metrics-lua_5530.json`

Note: the `page=fiberFiber` / `sfpProperties` indices are **unverified** — my box runs on DSL, where that page returns no `sfpProperties`. Confirmation from a 5690 Pro on a fiber uplink welcome.